### PR TITLE
fix: change throttle window to 200 ms

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -7,7 +7,7 @@ let globalKey = 0;
 // queue & timer for throttling:
 let messageQueue = {};       // { authorId: payload }
 let processTimer = null;
-const PROCESS_DELAY = 50;    // 50ms throttle window
+const PROCESS_DELAY = 200;    // throttle window (ms)
 
 exports.aceInitInnerdocbodyHead = (hookName, args, cb) => {
   const url = '../static/plugins/ep_cursortrace/static/css/ace_inner.css';


### PR DESCRIPTION
50 ms might be too low - should test something higher to see if alleviates client-side resource usage any further.

Increase the throttle window from 50 ms to 200 ms.