### PR TITLE
fix: implement client-side throttle for SENDING cursor updates

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -117,7 +117,6 @@ function flushCursorUpdate() {
   const msg = pendingCursorUpdate;
   pendingCursorUpdate = null;
 
-  // console.log('Sending throttled local cursor update', msg);
   pad.collabClient.sendMessage(msg);
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,7 +4,12 @@ let initiated = false;
 let last = undefined;
 let globalKey = 0;
 
-// queue & timer for throttling:
+// Client-side throttle before sending cursor updates to server
+const CLIENT_CURSOR_THROTTLE_MS = 200;
+let pendingCursorUpdate = null;
+let cursorSendTimer = null;
+
+// queue & timer for throttling (incoming remote updates):
 let messageQueue = {};       // { authorId: payload }
 let processTimer = null;
 const PROCESS_DELAY = 200;    // 200ms throttle window
@@ -71,8 +76,7 @@ exports.aceEditEvent = (hook_name, args) => {
       };
       last = [Y, X];
 
-      // console.log("Sent message", message);
-      pad.collabClient.sendMessage(message);
+      queueCursorUpdate(message);
     }
   }
   return;
@@ -103,6 +107,29 @@ exports.handleClientMessage_CUSTOM = (hook, context, cb) => {
 
   return cb();
 };
+
+// Send the latest local cursor update at most once every CLIENT_CURSOR_THROTTLE_MS.
+function flushCursorUpdate() {
+  cursorSendTimer = null;
+
+  if (!pendingCursorUpdate) return;
+
+  const msg = pendingCursorUpdate;
+  pendingCursorUpdate = null;
+
+  // console.log('Sending throttled local cursor update', msg);
+  pad.collabClient.sendMessage(msg);
+}
+
+function queueCursorUpdate(msg) {
+  pendingCursorUpdate = msg;
+
+  if (cursorSendTimer) return;
+
+  cursorSendTimer = setTimeout(() => {
+    flushCursorUpdate();
+  }, CLIENT_CURSOR_THROTTLE_MS);
+}
 
 // Process messages in bulk
 function processQueuedMessages() {


### PR DESCRIPTION
In 7010b40, client-side throttling was introduced to defer the processing of incoming cursor updates from other users editing the pad. However, cursor update messages were still being sent from the sending client to the server, which would then broadcast them to all other users of that pad, potentially flooding receiving clients with cursor update messages.

A particularly critical scenario is when a user holds down a key in the pad, spamming cursor update messages to all other connected users. This can cause receiving clients to slow down or even freze.

This commit adds a throttle mechanism on the sending end to prevent this flood at the source. Although a deferred processing mechanism already exists on the receiving side, it occurs further down in Etherpad's processing flow — meaning it still consumes some resources for suppressed messages. Throttling at the sending end makes the system more robust on both sides.